### PR TITLE
feat: lazily load non-critical images

### DIFF
--- a/src/scenes/aboutme/index.tsx
+++ b/src/scenes/aboutme/index.tsx
@@ -22,6 +22,7 @@ const AboutMe = ({ setSelectedPage }: Props) => {
               className="mx-auto"
               alt="aboutme-page-graphic"
               src={AboutMeGraphic}
+              loading="lazy"
             />
             {/** DESCRIPTION */}
             <div>

--- a/src/scenes/home/index.tsx
+++ b/src/scenes/home/index.tsx
@@ -88,25 +88,22 @@ const Home = ({ setSelectedPage }: Props) => {
       </motion.div>
       {/** SPONSORS */}
       {isAboveMediumScreens && (
-        <div className=" w-full bg-primary-100 py-10 flex-col justify-items-center">
-          <div className="flex justify-center">
-            <h1 className="basis-3/5 font-montserrat text-3xl font-bold text-center pb-10">
-              Core Programming Technologies
-            </h1>
-          </div>
-          <div className="flex justify-center ">
-            <div className="flex w-3/5 items-center justify-between gap-8">
-              <img alt="html-logo" src={HTMLLogo} />
-              <img alt="css-logo" src={CSSLogo} />
-              <img alt="javascript-logo" src={JSLogo} />
-              <img
-                className="h-[100px] w-[100px]"
-                alt="react-logo"
-                src={ReactLogo}
-              />
-              <img alt="tailwind-css-logo" src={TailwindLogo} />
-              <img alt="typescript-logo" src={TSLogo} />
-            </div>
+        <div className="w-full bg-primary-100 py-10 flex flex-col items-center">
+          <h1 className="basis-3/5 pb-10 text-center font-montserrat text-3xl font-bold">
+            Core Programming Technologies
+          </h1>
+          <div className="flex w-3/5 flex-wrap items-center justify-center gap-8">
+            <img alt="html-logo" src={HTMLLogo} loading="lazy" />
+            <img alt="css-logo" src={CSSLogo} loading="lazy" />
+            <img alt="javascript-logo" src={JSLogo} loading="lazy" />
+            <img
+              className="h-[100px] w-[100px]"
+              alt="react-logo"
+              src={ReactLogo}
+              loading="lazy"
+            />
+            <img alt="tailwind-css-logo" src={TailwindLogo} loading="lazy" />
+            <img alt="typescript-logo" src={TSLogo} loading="lazy" />
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- add lazy loading for technology logos on home page
- lazy load About Me illustration
- center Core Programming Technologies logos with flex layout

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type; Redundant double negation)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b0d7889588330ae0c2830de6ec79d